### PR TITLE
bug fix, root user

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,6 @@ services:
     restart: always
     environment:
       MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
-      MYSQL_USER: "root"
       MYSQL_ROOT_PASSWORD: "dksdlfduq2"
       MYSQL_DATABASE: "mobiusdb"
     ports:


### PR DESCRIPTION
``` MYSQL_USER: "root" ``` this will cause an issue.  
```[ERROR] [Entrypoint]: MYSQL_USER="root", MYSQL_USER and MYSQL_PASSWORD are for configuring a regular user and cannot be used for the root user```

the `root` will be automatically created  https://stackoverflow.com/a/66910240/13577765
